### PR TITLE
Add pathPrefix for deployment

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,6 +1,7 @@
 import type { GatsbyConfig } from "gatsby";
 
 const config: GatsbyConfig = {
+  pathPrefix: "/DeveloperPortfolio",
   siteMetadata: {
     title: `Liam MacPherson Developer Portfolio`,
     siteUrl: `https://www.yourdomain.tld`


### PR DESCRIPTION
As the site is hosted not at the root domain but has the repository name as a prefix, this change adds the pathPrefix for this. This enables the deploment to correctly access static files.