### PR TITLE
Update thumbnail image name

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,7 @@ const IndexPage: React.FC<PageProps> = () => {
           </div>
           <StaticImage
             className="rounded-full mx-auto"
-            src="../images/Thumbnail.png"
+            src="../images/thumbnail.png"
             alt="Liam MacPherson"
             width={256} height={256}
             placeholder="blurred"


### PR DESCRIPTION
A previous change uppercased the image name but not the file. This change reverts this as the style to be followed should be lowercase. 