### PR TITLE
Change StaticImage to GatsbyImage

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -12,7 +12,15 @@ const config: GatsbyConfig = {
   graphqlTypegen: true,
   plugins: [
     "gatsby-plugin-postcss", 
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/src/images`,
+        name: 'images'
+      }
+    },
     "gatsby-plugin-image",
+    "gatsby-transformer-sharp",
     "gatsby-plugin-sharp"
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "gatsby-plugin-postcss": "^6.11.0",
         "gatsby-plugin-sharp": "^5.11.0",
         "gatsby-source-filesystem": "^5.11.0",
+        "gatsby-transformer-sharp": "^5.11.0",
         "postcss": "^8.4.25",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -9118,6 +9119,28 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-transformer-sharp": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.11.0.tgz",
+      "integrity": "sha512-kIYrCtceqmgwgPRQGVbVY8JxMfJulFSqAeLigRYhrxpVYag90vskmh+HsiKHaY9j/rEARyCofnaAG/jwhSrcRg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "bluebird": "^3.7.2",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-plugin-utils": "^4.11.0",
+        "probe-image-size": "^7.2.3",
+        "semver": "^7.5.1",
+        "sharp": "^0.32.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^5.0.0-next",
+        "gatsby-plugin-sharp": "^5.0.0-next"
       }
     },
     "node_modules/gatsby-worker": {
@@ -22951,6 +22974,21 @@
         "is-docker": "^2.2.1",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.11"
+      }
+    },
+    "gatsby-transformer-sharp": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.11.0.tgz",
+      "integrity": "sha512-kIYrCtceqmgwgPRQGVbVY8JxMfJulFSqAeLigRYhrxpVYag90vskmh+HsiKHaY9j/rEARyCofnaAG/jwhSrcRg==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "bluebird": "^3.7.2",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-plugin-utils": "^4.11.0",
+        "probe-image-size": "^7.2.3",
+        "semver": "^7.5.1",
+        "sharp": "^0.32.1"
       }
     },
     "gatsby-worker": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-postcss": "^6.11.0",
     "gatsby-plugin-sharp": "^5.11.0",
     "gatsby-source-filesystem": "^5.11.0",
+    "gatsby-transformer-sharp": "^5.11.0",
     "postcss": "^8.4.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { Link } from "gatsby";
-import { StaticImage } from "gatsby-plugin-image";
+import { Link, graphql, useStaticQuery } from "gatsby";
+import { GatsbyImage } from "gatsby-plugin-image";
 
 export const Header: React.FC<HeaderProps> = ({ showHeading = true, navLinks = [] }) => {
 
@@ -37,15 +37,27 @@ export const Header: React.FC<HeaderProps> = ({ showHeading = true, navLinks = [
 }
 
 const Heading = () => {
+  const headerImage = useStaticQuery(graphql`
+  query {
+    thumbnail: file(relativePath: { eq: "thumbnail.png" }) {
+      childImageSharp {
+        gatsbyImageData(
+          layout: FIXED
+          placeholder: BLURRED
+          width: 40
+        )
+      }
+    }
+  }
+`);
+
   return (
     <div className="flex lg:flex-1">
-      <StaticImage
+      <GatsbyImage
         className="rounded-full"
-        src="../images/thumbnail.png"
+        image={headerImage.thumbnail.childImageSharp.gatsbyImageData}
         alt="Liam MacPherson"
-        width={40} height={40}
-        placeholder="blurred"
-        layout="fixed" />
+      />
       <Link to="/" className="px-2 py-2 font-bold">Liam MacPherson</Link>
     </div>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 import type { HeadFC, PageProps } from "gatsby"
+import { graphql } from "gatsby";
 import { Footer } from "../components/Footer"
-import { StaticImage } from "gatsby-plugin-image";
+import { GatsbyImage } from "gatsby-plugin-image";
 
-const IndexPage: React.FC<PageProps> = () => {
+const IndexPage: React.FC<PageProps> = ({data}) => {
   return (
     <React.Fragment>
       <main className="flex flex-col flex-auto bg-gray-100/80">
@@ -28,14 +29,14 @@ const IndexPage: React.FC<PageProps> = () => {
               }}
             />
           </div>
-          <StaticImage
+          <div className="flex px-10">
+          <GatsbyImage
             className="rounded-full mx-auto"
-            src="../images/thumbnail.png"
-            alt="Liam MacPherson"
-            width={256} height={256}
-            placeholder="blurred"
-            layout="fixed" />
-          <h1 className="font-semibold text-center text-3xl pt-4">Liam MacPherson</h1>
+            image={data.heroImage.childImageSharp.gatsbyImageData}
+            alt="Liam MacPherson"/>
+          </div>
+          
+          <h1 className="font-semibold text-center text-3xl pt-6">Liam MacPherson</h1>
           <p className="text-center text-md py-1 px-10 sm:typing-animation">I'm a full-stack developer and coffee enthusiast ☕</p>
         </div>
         <div className="bg-gray-300/40">
@@ -98,5 +99,18 @@ const IndexPage: React.FC<PageProps> = () => {
 }
 
 export const Head: HeadFC = () => <title>Liam MacPherson</title>
+
+export const pageQuery = graphql`
+  query {
+    heroImage: file(relativePath: { eq: "thumbnail.png" }) {
+      childImageSharp {
+        gatsbyImageData(
+          placeholder: BLURRED
+          width: 256
+        )
+      }
+    }
+  }
+`
 
 export default IndexPage


### PR DESCRIPTION
The thumbnail was previously a static image that causes issues with smaller devices with resizing. This change reworks these images to become dynamic GatsbyImage, this enables the dynamic resizing. Further improvements also include the use of the `gatsby-source-filesystem` plugin that enables the retrieval of the images with `graphql`, this retrieves the image and then further enhances it.